### PR TITLE
Don't start asm-worker and wasm-worker until runtime is fully loaded

### DIFF
--- a/src/asm-worker.js
+++ b/src/asm-worker.js
@@ -1,3 +1,5 @@
 var Module = {};
+Module['onRuntimeInitialized'] = function() {
+  postMessage({msg: 'asm'});
+}
 importScripts('cv-asm.js', 'worker.js');
-postMessage({msg: 'asm'});

--- a/src/main-video.js
+++ b/src/main-video.js
@@ -146,7 +146,8 @@ function updateCanvas(e, targetCanvas, plot) {
 wasmWorker.onmessage = function (e) {
     if (e.data.msg == 'wasm') {
         if (canvases.ready) { 
-            setTimeout(detect, 2000) }
+            detect();
+        }
         else {
             canvases.ready = true
         }
@@ -162,7 +163,9 @@ wasmWorker.onmessage = function (e) {
 
 asmWorker.onmessage = function (e) {
     if (e.data.msg == 'asm') {
-        if (canvases.ready) { setTimeout(detect, 2000)}
+        if (canvases.ready) {
+            detect();
+        }
         else {
             canvases.ready = true
         }

--- a/src/wasm-worker.js
+++ b/src/wasm-worker.js
@@ -1,3 +1,5 @@
 var Module = {};
+Module['onRuntimeInitialized'] = function() {
+  postMessage({msg: 'wasm'});
+}
 importScripts('cv-wasm.js', 'worker.js');
-postMessage({msg: 'wasm'});


### PR DESCRIPTION
This addresses the issue reported in #17.  The worker's aren't reporting 'ready' back to main until the onRuntimeInitialized function has been invoked.  The setTimout(detect,..) calls in main-video.js are no longer necessary.